### PR TITLE
Provide ability to explicitly set the name of archivable item

### DIFF
--- a/lib/tartarus/archivable_item.rb
+++ b/lib/tartarus/archivable_item.rb
@@ -1,7 +1,7 @@
 class Tartarus::ArchivableItem
   REQUIRED_ATTRIBUTES_NAMES = %i(model cron queue archive_items_older_than timestamp_field active_job
     archive_with tenant_value_source).freeze
-  OPTIONAL_ATTRIBUTES_NAMES = %i(tenants_range tenant_id_field batch_size remote_storage).freeze
+  OPTIONAL_ATTRIBUTES_NAMES = %i(tenants_range tenant_id_field batch_size remote_storage name).freeze
 
   attr_accessor *(REQUIRED_ATTRIBUTES_NAMES + OPTIONAL_ATTRIBUTES_NAMES)
 
@@ -51,6 +51,10 @@ class Tartarus::ArchivableItem
     @batch_size ||= 10_000
   end
 
+  def name
+    @name || @model.to_s
+  end
+
   def validate!
     validate_presence
   end
@@ -61,10 +65,6 @@ class Tartarus::ArchivableItem
 
   def archive_strategy(factory: Tartarus::ArchiveStrategy.new)
     factory.for(archive_with, batch_size: batch_size)
-  end
-
-  def for_model?(provided_model_name)
-    model.to_s == provided_model_name.to_s
   end
 
   def remote_storage

--- a/lib/tartarus/archivable_item/sidekiq_cron_job_serializer.rb
+++ b/lib/tartarus/archivable_item/sidekiq_cron_job_serializer.rb
@@ -7,7 +7,7 @@ class Tartarus
           description: description_for_item(archivable_item),
           cron: archivable_item.cron,
           class: Tartarus::Sidekiq::ScheduleArchivingModelJob,
-          args: [archivable_item.model],
+          args: [archivable_item.name],
           queue: archivable_item.queue,
           active_job: archivable_item.active_job
         }
@@ -16,7 +16,7 @@ class Tartarus
       private
 
       def name_for_item(archivable_item)
-        "TARTARUS_#{archivable_item.model}"
+        "TARTARUS_#{archivable_item.name}"
       end
 
       def description_for_item(archivable_item)

--- a/lib/tartarus/archive_model_with_tenant.rb
+++ b/lib/tartarus/archive_model_with_tenant.rb
@@ -7,20 +7,20 @@ class Tartarus::ArchiveModelWithTenant
     @repository = repository
   end
 
-  def archive(model_name, tenant_id)
-    archivable_item = registry.find_by_model(model_name)
-    collection = collection_to_archive(model_name, archivable_item, tenant_id)
-    archivable_item.remote_storage.store(collection, model_name, tenant_id: tenant_id,
+  def archive(archivable_item_name, tenant_id)
+    archivable_item = registry.find_by_name(archivable_item_name)
+    collection = collection_to_archive(archivable_item, tenant_id)
+    archivable_item.remote_storage.store(collection, archivable_item.name, tenant_id: tenant_id,
       tenant_id_field: archivable_item.tenant_id_field)
     archivable_item.archive_strategy.call(collection)
   end
 
   private
 
-  def collection_to_archive(model_name, archivable_item, tenant_id)
+  def collection_to_archive(archivable_item, tenant_id)
     repository
       .items_older_than_for_tenant(
-        model_name,
+        archivable_item.model,
         archivable_item.timestamp_field, archivable_item.archive_items_older_than.call,
         archivable_item.tenant_id_field, tenant_id
       )

--- a/lib/tartarus/archive_model_without_tenant.rb
+++ b/lib/tartarus/archive_model_without_tenant.rb
@@ -7,19 +7,19 @@ class Tartarus::ArchiveModelWithoutTenant
     @repository = repository
   end
 
-  def archive(model_name)
-    archivable_item = registry.find_by_model(model_name)
-    collection = collection_to_archive(model_name, archivable_item)
-    archivable_item.remote_storage.store(collection, model_name)
+  def archive(archivable_item_name)
+    archivable_item = registry.find_by_name(archivable_item_name)
+    collection = collection_to_archive(archivable_item)
+    archivable_item.remote_storage.store(collection, archivable_item.name)
     archivable_item.archive_strategy.call(collection)
   end
 
   private
 
-  def collection_to_archive(model_name, archivable_item)
+  def collection_to_archive(archivable_item)
     repository
       .items_older_than(
-        model_name,
+        archivable_item.model,
         archivable_item.timestamp_field, archivable_item.archive_items_older_than.call
       )
   end

--- a/lib/tartarus/registry.rb
+++ b/lib/tartarus/registry.rb
@@ -16,8 +16,8 @@ class Tartarus::Registry
     @storage << item
   end
 
-  def find_by_model(model)
-    storage.find(->{ raise "#{model} not found in registry" }) { |item| item.for_model?(model) }
+  def find_by_name(name)
+    storage.find(->{ raise "#{name} not found in registry" }) { |item| item.name == name }
   end
 
   def reset

--- a/lib/tartarus/schedule_archiving_model.rb
+++ b/lib/tartarus/schedule_archiving_model.rb
@@ -6,15 +6,15 @@ class Tartarus::ScheduleArchivingModel
     @registry = registry
   end
 
-  def schedule(model_name)
-    archivable_item = registry.find_by_model(model_name)
+  def schedule(archivable_item_name)
+    archivable_item = registry.find_by_name(archivable_item_name)
 
     if archivable_item.scope_by_tenant?
       each_tenant(archivable_item) do |tenant|
-        enqueue(Tartarus::Sidekiq::ArchiveModelWithTenantJob, archivable_item.queue, model_name, tenant)
+        enqueue(Tartarus::Sidekiq::ArchiveModelWithTenantJob, archivable_item.queue, archivable_item.name, tenant)
       end
     else
-      enqueue(Tartarus::Sidekiq::ArchiveModelWithoutTenantJob, archivable_item.queue, model_name)
+      enqueue(Tartarus::Sidekiq::ArchiveModelWithoutTenantJob, archivable_item.queue, archivable_item.name)
     end
   end
 

--- a/lib/tartarus/sidekiq/archive_model_with_tenant_job.rb
+++ b/lib/tartarus/sidekiq/archive_model_with_tenant_job.rb
@@ -4,8 +4,8 @@ class Tartarus
   class Sidekiq::ArchiveModelWithTenantJob
     include ::Sidekiq::Worker
 
-    def perform(model_name, tenant_id)
-      Tartarus::ArchiveModelWithTenant.new.archive(model_name, tenant_id)
+    def perform(archivable_item_name, tenant_id)
+      Tartarus::ArchiveModelWithTenant.new.archive(archivable_item_name, tenant_id)
     end
   end
 end

--- a/lib/tartarus/sidekiq/archive_model_without_tenant_job.rb
+++ b/lib/tartarus/sidekiq/archive_model_without_tenant_job.rb
@@ -4,8 +4,8 @@ class Tartarus
   class Sidekiq::ArchiveModelWithoutTenantJob
     include ::Sidekiq::Worker
 
-    def perform(model_name)
-      Tartarus::ArchiveModelWithoutTenant.new.archive(model_name)
+    def perform(archivable_item_name)
+      Tartarus::ArchiveModelWithoutTenant.new.archive(archivable_item_name)
     end
   end
 end

--- a/lib/tartarus/sidekiq/schedule_archiving_model_job.rb
+++ b/lib/tartarus/sidekiq/schedule_archiving_model_job.rb
@@ -4,8 +4,8 @@ class Tartarus
   class Sidekiq::ScheduleArchivingModelJob
     include ::Sidekiq::Worker
 
-    def perform(model_name)
-      Tartarus::ScheduleArchivingModel.new.schedule(model_name)
+    def perform(archivable_item_name)
+      Tartarus::ScheduleArchivingModel.new.schedule(archivable_item_name)
     end
   end
 end

--- a/spec/integration/archiving_using_in_batches_spec.rb
+++ b/spec/integration/archiving_using_in_batches_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "Integration Test: Archiving Using In Batches From Rails 6" do
   subject(:archive) do
-    Tartarus::ArchiveModelWithTenant.new(registry: registry).archive(User, "Partition_1")
+    Tartarus::ArchiveModelWithTenant.new(registry: registry).archive("User", "Partition_1")
   end
 
   let(:registry) { Tartarus::Registry.new }

--- a/spec/integration/archiving_using_limit_in_batches_spec.rb
+++ b/spec/integration/archiving_using_limit_in_batches_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "Integration Test: Archiving Using DeleteAll With Limit In Batches" do
   subject(:archive) do
-    Tartarus::ArchiveModelWithTenant.new(registry: registry).archive(User, "Partition_1")
+    Tartarus::ArchiveModelWithTenant.new(registry: registry).archive("User", "Partition_1")
   end
 
   let(:registry) { Tartarus::Registry.new }

--- a/spec/integration/archiving_with_glacier_upload_spec.rb
+++ b/spec/integration/archiving_with_glacier_upload_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe "Archiving With Glacier Upload", :freeze_time do
   context "with tenant" do
     subject(:archive) do
-      Tartarus::ArchiveModelWithTenant.new(registry: registry).archive(User, "Partition_1")
+      Tartarus::ArchiveModelWithTenant.new(registry: registry).archive("User", "Partition_1")
     end
 
     let(:registry) { Tartarus::Registry.new }
@@ -114,7 +114,7 @@ RSpec.describe "Archiving With Glacier Upload", :freeze_time do
 
   context "without tenant" do
     subject(:archive) do
-      Tartarus::ArchiveModelWithoutTenant.new(registry: registry).archive(User)
+      Tartarus::ArchiveModelWithoutTenant.new(registry: registry).archive("User")
     end
 
     let(:registry) { Tartarus::Registry.new }

--- a/spec/integration/archiving_without_using_in_batches_spec.rb
+++ b/spec/integration/archiving_without_using_in_batches_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "Integration Test: Archiving Without Using In Batches From Rails 6" do
   subject(:archive) do
-    Tartarus::ArchiveModelWithoutTenant.new(registry: registry).archive(UserWithoutInBatches)
+    Tartarus::ArchiveModelWithoutTenant.new(registry: registry).archive("UserWithoutInBatches")
   end
 
   let(:registry) { Tartarus::Registry.new }

--- a/spec/integration/multiple_archivable_items_for_the_same_model_spec.rb
+++ b/spec/integration/multiple_archivable_items_for_the_same_model_spec.rb
@@ -1,0 +1,61 @@
+RSpec.describe "Integration Test: Archiving Without Using In Batches From Rails 6" do
+  subject(:archive) do
+    Tartarus::ArchiveModelWithoutTenant.new(registry: registry).archive("critical_users")
+  end
+
+  let(:registry) { Tartarus::Registry.new }
+  let(:archivable_item) do
+    Tartarus::ArchivableItem.new.tap do |item|
+      item.model = User
+      item.timestamp_field = :created_at
+      item.archive_items_older_than = -> { Time.new(2021, 1, 1, 12, 0, 0, 0) }
+      item.archive_with = archive_with
+      item.name = "critical_users"
+    end
+  end
+
+  let(:archivable_item_1) do
+    Tartarus::ArchivableItem.new.tap do |item|
+      item.model = User
+      item.timestamp_field = :created_at
+      item.archive_items_older_than = -> { Time.new(2025, 1, 1, 12, 0, 0, 0) }
+      item.archive_with = archive_with
+      item.name = "low_priority_users"
+    end
+  end
+  let(:archive_with) { :destroy_all }
+
+  before do
+    registry.register(archivable_item)
+    registry.register(archivable_item_1)
+
+    100.times { User.create!(created_at: Time.new(2020, 1, 1, 12, 0, 0, 0), partition_name: "Partition_1") }
+    50.times { User.create!(created_at: Time.new(2022, 1, 1, 12, 0, 0, 0), partition_name: "Partition_1") }
+    20.times { User.create!(created_at: Time.new(2024, 1, 1, 12, 0, 0, 0), partition_name: "Partition_1") }
+    10.times { User.create!(created_at: Time.new(2036, 1, 1, 12, 0, 0, 0), partition_name: "Partition_1") }
+  end
+
+  after do
+    User.delete_all
+  end
+
+  describe "for delete_all" do
+    let(:archive_with) { :delete_all }
+
+    it "deletes Users only with partition specified in critical_users strategy" do
+      expect {
+        archive
+      }.to change { User.count }.from(180).to(80)
+    end
+  end
+
+  describe "for destroy_all" do
+    let(:archive_with) { :destroy_all }
+
+    it "deletes Users only with partition specified in critical_users strategy" do
+      expect {
+        archive
+      }.to change { User.count }.from(180).to(80)
+    end
+  end
+end

--- a/spec/integration/scheduling_with_tenant_spec.rb
+++ b/spec/integration/scheduling_with_tenant_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "Integration Test: Scheduling Archiving With Tenant" do
   subject(:schedule) do
-    Tartarus::ScheduleArchivingModel.new(registry: registry).schedule(User)
+    Tartarus::ScheduleArchivingModel.new(registry: registry).schedule("User")
   end
 
   let(:registry) { Tartarus::Registry.new }

--- a/spec/integration/scheduling_without_tenant_spec.rb
+++ b/spec/integration/scheduling_without_tenant_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "Integration Test: Scheduling Archiving Without Tenant" do
   subject(:schedule) do
-    Tartarus::ScheduleArchivingModel.new(registry: registry).schedule(User)
+    Tartarus::ScheduleArchivingModel.new(registry: registry).schedule("User")
   end
 
   let(:registry) { Tartarus::Registry.new }

--- a/spec/tartarus/archivable_item/sidekiq_cron_job_serializer_spec.rb
+++ b/spec/tartarus/archivable_item/sidekiq_cron_job_serializer_spec.rb
@@ -3,14 +3,14 @@ RSpec.describe Tartarus::ArchivableItem::SidekiqCronJobSerializer do
     subject(:serialize) { serializer.serialize(item) }
 
     let(:serializer) { described_class.new }
-    let(:item) { double(model: "ModelName", cron: "* * * * *", active_job: false, queue: "default") }
+    let(:item) { double(model: "ModelName", cron: "* * * * *", active_job: false, queue: "default", name: "my_name") }
     let(:expected_hash) do
       {
-        name: "TARTARUS_ModelName",
+        name: "TARTARUS_my_name",
         description: "[TARTARUS] Archiving Job for model: ModelName",
         cron: "* * * * *",
         class: Tartarus::Sidekiq::ScheduleArchivingModelJob,
-        args: ["ModelName"],
+        args: ["my_name"],
         queue: "default",
         active_job: false
       }

--- a/spec/tartarus/archivable_item_spec.rb
+++ b/spec/tartarus/archivable_item_spec.rb
@@ -18,6 +18,30 @@ RSpec.describe Tartarus::ArchivableItem do
       end
     end
 
+    describe "name" do
+      subject(:name) { archivable_item.name }
+
+      context "when the attribute is not set" do
+        it { is_expected.to eq "" }
+      end
+
+      context "when the attribute is set" do
+        before do
+          archivable_item.name = "name"
+        end
+
+        it { is_expected.to eq "name" }
+      end
+
+      context "when the model is set" do
+        before do
+          archivable_item.model = String
+        end
+
+        it { is_expected.to eq "String" }
+      end
+    end
+
     describe "queue" do
       subject(:queue) { archivable_item.queue }
 
@@ -352,25 +376,6 @@ RSpec.describe Tartarus::ArchivableItem do
       end
 
       it { is_expected.to be_a Tartarus::ArchiveStrategy::DestroyAll }
-    end
-  end
-
-  describe "#for_model?" do
-    subject(:for_model?) { archivable_item.for_model?(provided_model) }
-
-    let(:archivable_item) { described_class.new.tap { |item| item.model = model } }
-    let(:model) { "ModelName" }
-
-    context "when provided model name is the one for which the item was created" do
-      let(:provided_model) { double(to_s: model) }
-
-      it { is_expected.to eq true }
-    end
-
-    context "when provided model name is not the one for which the item was created" do
-      let(:provided_model) { double(to_s: "Other") }
-
-      it { is_expected.to eq false }
     end
   end
 end

--- a/spec/tartarus/registry_spec.rb
+++ b/spec/tartarus/registry_spec.rb
@@ -1,12 +1,12 @@
 RSpec.describe Tartarus::Registry do
-  describe "#find_by_model" do
-    subject(:find_by_model) { registry.find_by_model(model) }
+  describe "#find_by_name" do
+    subject(:find_by_name) { registry.find_by_name(name) }
 
     let(:registry) { described_class.new }
-    let(:model_1) { double(to_s: "OtherModelName") }
-    let(:item_1) { Tartarus::ArchivableItem.new.tap { |item| item.model = model_1 } }
-    let(:model) { double(to_s: "ModelName") }
-    let(:item) { Tartarus::ArchivableItem.new.tap { |item| item.model = model } }
+    let(:name_1) { "OtherModelName" }
+    let(:item_1) { Tartarus::ArchivableItem.new.tap { |item| item.name = name_1 } }
+    let(:name) { "ModelName" }
+    let(:item) { Tartarus::ArchivableItem.new.tap { |item| item.name = name } }
 
     before do
       registry.register(item_1)

--- a/spec/tartarus_spec.rb
+++ b/spec/tartarus_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Tartarus do
           register
         }.to change { registry.size }.from(0).to(1)
 
-        expect(registry.find_by_model(model)).to be_a(Tartarus::ArchivableItem)
+        expect(registry.find_by_name(model)).to be_a(Tartarus::ArchivableItem)
       end
     end
 


### PR DESCRIPTION
It shouldn't break clients which already use Tartarus. Name fallbacks to `model.to_s` if it's not set