### PR TITLE
ensure ordering by timestamp when archiving without tenant

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## Master
 
+- Optimize query from `Tartarus::ArchivableCollectionRepository#items_older_than` by adding explicit ordering
+
 ## 0.5.0
 
 - Provide ability to explicitly set the name of archivable item to have multiple ways of archiving the same model

--- a/lib/tartarus/archivable_collection_repository.rb
+++ b/lib/tartarus/archivable_collection_repository.rb
@@ -20,7 +20,7 @@ class Tartarus
       collection = collection_for(model_name)
       ensure_column_exists(collection, model_name, timestamp_field)
 
-      collection.where("#{timestamp_field} < ?", timestamp)
+      collection.where("#{timestamp_field} < ?", timestamp).order(timestamp_field)
     end
 
     private

--- a/spec/tartarus/archivable_collection_repository_spec.rb
+++ b/spec/tartarus/archivable_collection_repository_spec.rb
@@ -78,10 +78,17 @@ RSpec.describe Tartarus::ArchivableCollectionRepository do
         ]
       end
 
+      let(:expected_order) do
+        [
+          :created_at
+        ]
+      end
+
       it "queries the target collection using ActiveRecord-like interface returning the collection" do
         expect {
           items_older_than
         }.to change { collection.where_statements }.from([]).to(expected_where_statements)
+        .and change { collection.order_by }.from([]).to(expected_order)
       end
 
       it "returns the collection" do

--- a/spec/tartarus/sidekiq/archive_model_without_tenant_job_spec.rb
+++ b/spec/tartarus/sidekiq/archive_model_without_tenant_job_spec.rb
@@ -12,6 +12,11 @@ RSpec.describe Tartarus::Sidekiq::ArchiveModelWithoutTenantJob do
         [{ "id" => ModelNameForTestingArchiveModelWithoutTenantJob }]
       ]
     end
+    let(:expected_order) do
+      [
+        :created_at
+      ]
+    end
 
     around do |example|
       tartarus.register do |item|
@@ -34,6 +39,7 @@ RSpec.describe Tartarus::Sidekiq::ArchiveModelWithoutTenantJob do
       expect {
         perform
       }.to change { ModelNameForTestingArchiveModelWithoutTenantJob.where_statements }.from([]).to(expected_where_statements)
+      .and change { ModelNameForTestingArchiveModelWithoutTenantJob.order_by }.from([]).to(expected_order)
       .and change { ModelNameForTestingArchiveModelWithoutTenantJob.deleted? }.from(nil).to(true)
       .and change { ModelNameForTestingArchiveModelWithoutTenantJob.select_value }.from(nil).to("id")
     end
@@ -48,12 +54,21 @@ RSpec.describe Tartarus::Sidekiq::ArchiveModelWithoutTenantJob do
       @where_statements ||= []
     end
 
+    def self.order_by
+      @order_by ||= []
+    end
+
     def self.select_value
       @select_value
     end
 
     def self.where(*args)
       where_statements << [*args]
+      self
+    end
+
+    def self.order(*args)
+      @order_by = [*args]
       self
     end
 


### PR DESCRIPTION
The query was super under optimized without explicit ordering as the records were getting sorted by ID. By adding ordering by the same field we perform filtering with, it got way faster (tested already in one of the apps).