### PR TITLE
Remove order query from the collection

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## Master
 
+- Remove explicit ordering from `Tartarus::ArchivableCollectionRepository#items_older_than`, it increased the cost of queries significantly on large tables
+
 ## 0.6.0
 
 - Optimize query from `Tartarus::ArchivableCollectionRepository#items_older_than` by adding explicit ordering

--- a/lib/tartarus/archivable_collection_repository.rb
+++ b/lib/tartarus/archivable_collection_repository.rb
@@ -13,7 +13,6 @@ class Tartarus
       ensure_column_exists(collection, model_name, tenant_id_field)
 
       collection.where("#{timestamp_field} < ?", timestamp).where(tenant_id_field => tenant_id)
-                .order(tenant_id_field, timestamp_field)
     end
 
     def items_older_than(model_name, timestamp_field, timestamp)

--- a/spec/tartarus/archivable_collection_repository_spec.rb
+++ b/spec/tartarus/archivable_collection_repository_spec.rb
@@ -33,18 +33,10 @@ RSpec.describe Tartarus::ArchivableCollectionRepository do
         ]
       end
 
-      let(:expected_order) do
-        [
-          "tenant_id",
-          :created_at
-        ]
-      end
-
       it "queries the target collection using ActiveRecord-like interface returning the collection" do
         expect {
           items_older_than_for_tenant
         }.to change { collection.where_statements }.from([]).to(expected_where_statements)
-        .and change { collection.order_by }.from([]).to(expected_order)
       end
 
       it "returns the collection" do
@@ -130,21 +122,15 @@ RSpec.describe Tartarus::ArchivableCollectionRepository do
   end
   let(:collection) do
     Class.new do
-      attr_reader :column_names, :where_statements, :order_by
+      attr_reader :column_names, :where_statements
 
       def initialize(column_names)
         @column_names = column_names
         @where_statements = []
-        @order_by = []
       end
 
       def where(*args)
         @where_statements << [*args]
-        self
-      end
-
-      def order(*args)
-        @order_by = [*args]
         self
       end
     end.new(column_names)


### PR DESCRIPTION
It increased the cost of the query significantly causing possible timeouts. It does not look like it is needed anymore to force use of index to search for records, possibly this is due to AR internals changes.

Removing the order by part of the query and checking the query plan on one of our apps reduces the cost from `15988663.92..16812181.97` to `4060.71..827578.75`