### PR TITLE
Remove explicit order from both items older than methods

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## Master
 
+- Remove explicit ordering from both `Tartarus::ArchivableCollectionRepository#items_older_than` and `Tartarus::ArchivableCollectionRepository#items_older_than_for_tenant`
+
 ## 0.7.0
 
 - Remove explicit ordering from `Tartarus::ArchivableCollectionRepository#items_older_than`, it increased the cost of queries significantly on large tables

--- a/lib/tartarus/archivable_collection_repository.rb
+++ b/lib/tartarus/archivable_collection_repository.rb
@@ -19,7 +19,7 @@ class Tartarus
       collection = collection_for(model_name)
       ensure_column_exists(collection, model_name, timestamp_field)
 
-      collection.where("#{timestamp_field} < ?", timestamp).order(timestamp_field)
+      collection.where("#{timestamp_field} < ?", timestamp)
     end
 
     private

--- a/spec/tartarus/archivable_collection_repository_spec.rb
+++ b/spec/tartarus/archivable_collection_repository_spec.rb
@@ -70,17 +70,10 @@ RSpec.describe Tartarus::ArchivableCollectionRepository do
         ]
       end
 
-      let(:expected_order) do
-        [
-          :created_at
-        ]
-      end
-
       it "queries the target collection using ActiveRecord-like interface returning the collection" do
         expect {
           items_older_than
         }.to change { collection.where_statements }.from([]).to(expected_where_statements)
-        .and change { collection.order_by }.from([]).to(expected_order)
       end
 
       it "returns the collection" do


### PR DESCRIPTION
Only noticed the non-tenant method uses order as well. Removed the order from there as well.
 
