### PR TITLE
Sync Gemfile.lock with widened sidekiq-cron constraint

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## Master
 
+- Sync `Gemfile.lock` with the widened `sidekiq-cron >= 1` constraint in the gemspec to fix frozen-mode `bundle install` on CI
+
 ## 0.9.0
 
 - Require sidekiq-cron >= 2 (Sidekiq 8 compatibility)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     tartarus-rb (0.9.0)
       sidekiq (>= 5)
-      sidekiq-cron (>= 2)
+      sidekiq-cron (>= 1)
 
 GEM
   remote: https://rubygems.org/


### PR DESCRIPTION
## Summary
- Commit 1479343 relaxed the `sidekiq-cron` gemspec requirement from `>= 2` to `>= 1`, but `Gemfile.lock` still pinned `sidekiq-cron (>= 2)` under the `tartarus-rb` `PATH` block.
- CI runs `bundle install` in `--deployment` (frozen) mode, so Bundler detected the path-gem gemspec drift and exited with code 16: _"The gemspecs for path gems changed, but the lockfile can't be updated because frozen mode is set."_
- Regenerated `Gemfile.lock` so it matches the gemspec; no other dependency versions changed.
- Added a `## Master` changelog entry.

## Test plan
- [ ] CI `bundle install` step succeeds on this branch
- [ ] Test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)